### PR TITLE
Add main, start and offline scripts

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+import time, logging, argparse, start, setup
+
+parser = argparse.ArgumentParser(prog='airmon', usage='%(prog)s [start] [setup] [-h]')
+parser.add_argument('command', choices=['start', 'setup'])
+args = parser.parse_args()
+
+if args.command == 'start':
+    start.main()
+elif args.command == 'setup':
+    setup.main()
+else:
+    parser.print_help()

--- a/offline.py
+++ b/offline.py
@@ -1,0 +1,21 @@
+import json
+
+class Offline:
+
+    def __init__(self, pm_two_five_file, pm_ten_file):
+        self.pm_two_five_file = pm_two_five_file
+        self.pm_ten_file = pm_ten_file
+
+    def print_pm_two_five(self, pm_two_five):
+        print(str.format("PM 2.5 {0}", pm_two_five))
+
+    def print_pm_ten(self, pm_ten):
+        print(str.format("PM 10 {0}", pm_ten))
+
+    def write_pm_two_five(self, pm_two_five):
+        with open(self.pm_two_five_file, 'a') as file:
+            json.dump(pm_two_five, file)
+
+    def write_pm_ten(self, pm_ten):
+        with open(self.pm_ten_file, 'a') as file:
+            json.dump(pm_ten, file)

--- a/start.py
+++ b/start.py
@@ -1,0 +1,54 @@
+from app.sensor import Sensor
+from app.uploader import Uploader
+from app.offline import Offline
+import time, logging, argparse, sys, random, datetime
+
+logging.basicConfig(filename='airquality.log', level=logging.DEBUG, filemode='a',
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+sen = Sensor('PM Sensor 1', '/dev/ttyUSB0', b'\xaa', b'0xAB', b'\xc0')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o','--offline', action="store_true")
+
+    args = parser.parse_args(sys.argv[2:])
+
+    if args.offline:
+        start_offline()
+    else:
+        try:
+            start_online()
+        except:
+            start_offline()
+
+def start_offline():
+    print("Starting Air Monitor in offline mode")
+    off = Offline('pm25', 'pm10')
+    while True:
+        data = sen.read_from_sensor()
+        sen.check_message(data)
+        pm_two_five = sen.get_pm_two_five(data)
+        pm_ten = sen.get_pm_ten(data)
+        off.write_pm_two_five(pm_two_five)
+        off.write_pm_ten(pm_ten)
+
+def start_online():
+    print("Starting Air Monitor")
+    file = 'config.yml'
+    up = Uploader('AIO')
+    username, key, feed_two_five, feed_ten = up.read_config(file)
+    aio = up.connect_to_aio(username, key)
+    while True:
+        up.get_feeds(aio)
+        data = sen.read_from_sensor()
+        sen.check_message(data)
+        pm_two_five = sen.get_pm_two_five(data)
+        pm_ten = sen.get_pm_ten(data)
+
+        up.send_to_aio(aio, feed_two_five, pm_two_five)
+        up.send_to_aio(aio, feed_ten, pm_ten)
+
+        print(up.retrieve_from_feed(aio, feed_two_five))
+        print(up.retrieve_from_feed(aio, feed_ten))
+        time.sleep(60)


### PR DESCRIPTION
 Adds main script, start script and offline mode script

**Main**
- Command line Argument parser to allow for selection of setup or start modes

**Offline**
- Offline script allows for writing of sensor PM values to system out or json file

**Start**
- Start script allows for selection of online (default) or offline modes
- Creates uploader and sensor instances
- Sensor instance initialised with defaults for serial port and expected input byte patterns
- Orchestrates connection to sensor, reading of PM data, connection to AIO API and uploading of data
